### PR TITLE
Elaz/send tx

### DIFF
--- a/KinSDK/KinSDK.xcodeproj/project.pbxproj
+++ b/KinSDK/KinSDK.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		E970C2741FAE394D0091181B /* Contract.swift in Sources */ = {isa = PBXBuildFile; fileRef = E970C2731FAE394D0091181B /* Contract.swift */; };
 		E98B43E21FB1EFCB00B00A3C /* contractABI.json in Resources */ = {isa = PBXBuildFile; fileRef = E98B43E11FB1EFC600B00A3C /* contractABI.json */; };
 		E98B43E41FB1F06700B00A3C /* contractABI.json in Resources */ = {isa = PBXBuildFile; fileRef = E98B43E11FB1EFC600B00A3C /* contractABI.json */; };
+		E9D58CD11FB79B9C0035846D /* KinToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D58CD01FB79B9C0035846D /* KinToken.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +90,7 @@
 		827835471FA9B5F20006C3DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E970C2731FAE394D0091181B /* Contract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contract.swift; sourceTree = "<group>"; };
 		E98B43E11FB1EFC600B00A3C /* contractABI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = contractABI.json; sourceTree = "<group>"; };
+		E9D58CD01FB79B9C0035846D /* KinToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KinToken.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 				82140EAC1FA88E5B00FAF19B /* KinSDK.h */,
 				82140EAD1FA88E5B00FAF19B /* Info.plist */,
 				82140EC31FA88EAF00FAF19B /* Kin.swift */,
+				E9D58CD01FB79B9C0035846D /* KinToken.swift */,
 				82140EC81FA89A8600FAF19B /* KinAccountStore.swift */,
 				E970C2731FAE394D0091181B /* Contract.swift */,
 			);
@@ -360,6 +363,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9D58CD11FB79B9C0035846D /* KinToken.swift in Sources */,
 				82140EC91FA89A8600FAF19B /* KinAccountStore.swift in Sources */,
 				82140EC41FA88EAF00FAF19B /* Kin.swift in Sources */,
 				E970C2741FAE394D0091181B /* Contract.swift in Sources */,

--- a/KinSDK/KinSDK/Contract.swift
+++ b/KinSDK/KinSDK/Contract.swift
@@ -8,7 +8,7 @@
 
 enum ContractError: Error {
     case geth
-    case setup
+    case internalInconsistancy
 }
 
 class Contract {
@@ -16,11 +16,20 @@ class Contract {
     fileprivate var boundContract: GethBoundContract?
     fileprivate weak var context: GethContext?
     fileprivate weak var client: GethEthereumClient?
-    fileprivate let contractAddress = GethNewAddressFromHex("0xef2fcc998847db203dea15fc49d0872c7614910c", nil)
+    fileprivate let contractAddress: GethAddress
+    static let defaultGasLimit: Int64 = 4300000
     
-    init(with context: GethContext, client: GethEthereumClient) {
+    init(with context: GethContext, networkId: UInt64, client: GethEthereumClient) {
         self.context = context
         self.client = client
+        var address: String
+        switch networkId {
+        case NetworkIdMain:
+            address = "0x818fc6c2ec5986bc6e2cbf00939d90556ab12ce5"
+        default:
+            address = "0xef2fcc998847db203dea15fc49d0872c7614910c"
+        }
+        self.contractAddress = GethNewAddressFromHex(address, nil)
         bindContractAbi()
     }
     
@@ -37,32 +46,41 @@ class Contract {
     }
     
     func call(method: String, inputs: [GethInterface] = [],
-              outputs: [GethInterface],
-              options: GethCallOpts = GethNewCallOpts()) throws {
-
-        guard   let context = context,
-                let client = client else {
-                    throw ContractError.setup
-                    
-        }
+              outputs: [GethInterface]) throws {
         
-        let price = try client.suggestGasPrice(context).getInt64()
+        guard   let context = context,
+                let options = GethNewCallOpts(),
+                let contract = boundContract else {
+                throw ContractError.internalInconsistancy
+        }
         
         options.setContext(context)
-        options.setGasLimit(price)
         
-        let args = GethNewInterfaces(inputs.count)!
-        let outs = GethNewInterfaces(outputs.count)!
-        
-        for (i, input) in inputs.enumerated() {
-            try args.set(i, object: input)
-        }
-        for (i, output) in outputs.enumerated() {
-            try outs.set(i, object: output)
-        }
-        
-        try boundContract?.call(options, out_: outs, method: method, args: args)
+        try contract.call(options, out_: try outputs.interfaces(),
+                                method: method,
+                                args: try inputs.interfaces())
         
     }
     
+    func transact(method: String, options:GethTransactOpts,
+                  parameters: [GethInterface]) throws -> GethTransaction {
+        guard let contract = boundContract else {
+            throw ContractError.internalInconsistancy
+        }
+        return try contract.transact(options, method: method,
+                                    args: try parameters.interfaces())
+    }
+    
+}
+
+extension Array where Element == GethInterface {
+    func interfaces() throws -> GethInterfaces {
+        guard let interfaces = GethNewInterfaces(self.count) else {
+            throw KinError.invalidInput
+        }
+        for (i, object) in self.enumerated() {
+            try interfaces.set(i, object: object)
+        }
+        return interfaces
+    }
 }

--- a/KinSDK/KinSDK/KinAccountStore.swift
+++ b/KinSDK/KinSDK/KinAccountStore.swift
@@ -37,7 +37,7 @@ class KinAccountStore {
     
     let client: GethEthereumClient
     
-    fileprivate let keystore: GethKeyStore!
+    let keystore: GethKeyStore!
     let context = GethNewContext()!
     
     var accounts: GethAccounts {
@@ -45,7 +45,7 @@ class KinAccountStore {
             return keystore.getAccounts()
         }
     }
-    let networkId: Int64
+    let networkId: UInt64
 
     fileprivate var dataDir: String {
         return [
@@ -57,7 +57,7 @@ class KinAccountStore {
             .joined(separator: "/")
     }
 
-    init(url: URL, networkId: Int64) {
+    init(url: URL, networkId: UInt64) {
         self.networkId = networkId
 
         let dataDir = [

--- a/KinSDK/KinSDK/KinToken.swift
+++ b/KinSDK/KinSDK/KinToken.swift
@@ -1,0 +1,43 @@
+//
+//  KinToken.swift
+//  KinSDK
+//
+//  Created by Elazar Yifrach on 11/11/2017.
+//  Copyright © 2017 Kin Foundation. All rights reserved.
+//
+
+import Foundation
+
+public class KinToken {
+    
+    fileprivate let kinDecimal = Decimal(sign: .plus,
+                                            exponent: -18,
+                                            significand: Decimal(1))
+    
+    let value: Decimal
+    
+    init(string: String) throws {
+        guard let decimal = Decimal(string: string) else {
+            throw KinError.invalidInput
+        }
+        if (string.count > -kinDecimal.exponent) {
+            self.value = Decimal(sign: .plus,
+                                 exponent: kinDecimal.exponent,
+                                 significand: decimal)
+        } else {
+            guard let uint = UInt64(string) else {
+                throw KinError.invalidInput
+            }
+            self.value = Decimal(sign: .plus, exponent: 0,
+                                 significand: Decimal(uint))
+        }
+    }
+    
+    convenience init(bigInt: GethBigInt) throws {
+        try self.init(string: bigInt.string())
+    }
+    
+    public init(value: UInt64) {
+        self.value = Decimal(sign: .plus, exponent: 0, significand: Decimal(value))
+    }
+}

--- a/KinSDK/KinSDKTests/KinAccountStoreTests.swift
+++ b/KinSDK/KinSDKTests/KinAccountStoreTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class KinAccountStoreTests: XCTestCase {
 
     static let url = URL(string:"https://ropsten.infura.io/ciS27F9JQYk8MaJd8Fbu")!
-    static let networkId: Int64 = 3
+    static let networkId: UInt64 = NetworkIdMain
 
     let store = KinAccountStore(url: KinAccountStoreTests.url, networkId: 3)
     let creationPass = UUID().uuidString

--- a/KinSDK/KinSDKTests/KinAccountTests.swift
+++ b/KinSDK/KinSDKTests/KinAccountTests.swift
@@ -30,7 +30,7 @@ class KinAccountTests: XCTestCase {
 
     func test_publicAddress() {
         do {
-            let account = try kinClient.createAccountIfNecessary(with: passphrase)
+            let account = try kinClient.createAccountIfNeeded(with: passphrase)
             let publicAddress = account?.publicAddress
 
             XCTAssertNotNil(publicAddress, "Unable to retrieve public address for account: \(String(describing: account))")
@@ -44,7 +44,7 @@ class KinAccountTests: XCTestCase {
         
         var account:KinAccount!
         do {
-            account = try kinClient.createAccountIfNecessary(with: passphrase)
+            account = try kinClient.createAccountIfNeeded(with: passphrase)
             let balance = try account?.balance()
             XCTAssertNotNil(balance, "Unable to retrieve balance for account: \(String(describing: account))")
         }
@@ -58,7 +58,7 @@ class KinAccountTests: XCTestCase {
         
         var account:KinAccount!
         do {
-            account = try kinClient.createAccountIfNecessary(with: passphrase)
+            account = try kinClient.createAccountIfNeeded(with: passphrase)
         }
         catch {
             XCTAssertTrue(false, "Something went wrong: \(error)")
@@ -77,7 +77,7 @@ class KinAccountTests: XCTestCase {
     
     func test_decimals() {
         do {
-            let account = try kinClient.createAccountIfNecessary(with: passphrase)
+            let account = try kinClient.createAccountIfNeeded(with: passphrase)
             let decimals = try account?.decimals()
             
             XCTAssertNotNil(decimals, "Unable to retrieve decimals for account: \(String(describing: account))")

--- a/KinSDK/KinSDKTests/KinClientTests.swift
+++ b/KinSDK/KinSDKTests/KinClientTests.swift
@@ -20,20 +20,20 @@ class KinClientTests: XCTestCase {
 
         kinClient = try! KinClient(provider: provider)
     }
-    
+
     override func tearDown() {
         super.tearDown()
 
         let accountStore = KinAccountStore(url: provider.url, networkId: provider.networkId)
         try? accountStore.deleteKeystore()
     }
-    
+
     func test_account_creation() {
         var e: Error? = nil
         var account: KinAccount? = nil
 
         do {
-            account = try kinClient.createAccountIfNecessary(with: passphrase)
+            account = try kinClient.createAccountIfNeeded(with: passphrase)
         }
         catch {
             e = error
@@ -44,8 +44,8 @@ class KinClientTests: XCTestCase {
 
     func test_account_creation_limited_to_one() {
         do {
-            _ = try kinClient.createAccountIfNecessary(with: passphrase)
-            _ = try kinClient.createAccountIfNecessary(with: passphrase)
+            _ = try kinClient.createAccountIfNeeded(with: passphrase)
+            _ = try kinClient.createAccountIfNeeded(with: passphrase)
         }
         catch {
         }
@@ -58,7 +58,7 @@ class KinClientTests: XCTestCase {
 
     func test_keystore_export() {
         do {
-            let account = try kinClient.createAccountIfNecessary(with: passphrase)
+            let account = try kinClient.createAccountIfNeeded(with: passphrase)
             let privateKey = try kinClient.keyStore(with: passphrase)
 
             XCTAssertNotNil(privateKey, "Unable to retrieve private key for account: \(String(describing: account))")
@@ -66,5 +66,45 @@ class KinClientTests: XCTestCase {
         catch {
             XCTAssertTrue(false, "Something went wrong: \(error)")
         }
+    }
+    
+    func test_kinToken() {
+
+        let kin100FromDouble = KinToken(value: 100)
+        let bigIntShortString = GethNewBigInt(0)!
+        bigIntShortString.setString("100", base: 10)
+        let bigIntLongString = GethNewBigInt(0)!
+        bigIntLongString.setString("100000000000000000000", base: 10)
+        let bigIntLongStringReminder = GethNewBigInt(0)!
+        bigIntLongStringReminder.setString("100000000000000000001", base: 10)
+
+        guard let kin100FromUnder18CharsString = try? KinToken(string: "100") else {
+            XCTAssertTrue(false, "Kin could not be created from short string")
+            return
+        }
+        guard   let kin100FromOver18CharsString = try? KinToken(string: "100000000000000000000"),
+                let kin100FromOver18CharsStringWithReminder = try? KinToken(string: "100000000000000000001") else {
+            XCTAssertTrue(false, "Kin could not be created from long string")
+            return
+        }
+        guard   let KinFromBigIntWithInt = try? KinToken(bigInt: GethNewBigInt(100)),
+                let KinFromBigIntWithShortString = try? KinToken(bigInt: bigIntShortString),
+                let KinFromBigIntWithLongString = try? KinToken(bigInt: bigIntLongString),
+                let KinFromBigIntWithLongStringRemoinder = try? KinToken(bigInt: bigIntLongStringReminder) else {
+            XCTAssertTrue(false, "Kin could not be created from GethBigInt")
+            return
+        }
+
+        XCTAssertTrue((kin100FromUnder18CharsString.value as NSDecimalNumber).uint64Value == 100)
+        XCTAssertEqual(kin100FromUnder18CharsString.value, kin100FromOver18CharsString.value)
+        XCTAssertEqual(kin100FromDouble.value, kin100FromOver18CharsString.value)
+        XCTAssertTrue(String(describing: kin100FromOver18CharsString.value) == "100")
+        XCTAssertTrue(String(describing: kin100FromOver18CharsStringWithReminder.value) == "100.000000000000000001")
+        XCTAssertTrue(String(describing: KinFromBigIntWithLongStringRemoinder.value) == "100.000000000000000001")
+        XCTAssertNotEqual(kin100FromOver18CharsStringWithReminder.value, kin100FromOver18CharsString.value)
+        XCTAssertEqual(kin100FromDouble.value, KinFromBigIntWithLongString.value)
+        XCTAssertEqual(kin100FromDouble.value, KinFromBigIntWithShortString.value)
+        XCTAssertEqual(kin100FromDouble.value, KinFromBigIntWithInt.value)
+
     }
 }


### PR DESCRIPTION
Send transaction implementation, but derived from that:
Contract - get network id and deduce address
KinToken - a decimal wrapper for working with kin currency and interacting with Geth's big int, contract call results and uint64. For now, only initiating Uint64 values for kin is publicly supported.
