### PR TITLE
Convert kin<->wei at input and output.

### DIFF
--- a/KinSDK/KinSDK/extensions/Decimal+extensions.swift
+++ b/KinSDK/KinSDK/extensions/Decimal+extensions.swift
@@ -13,24 +13,25 @@ fileprivate let kinDecimal = Decimal(sign: .plus,
                                      significand: Decimal(1))
 
 extension Decimal {
-    init(kinString: String) throws {
-        guard let decimal = Decimal(string: kinString) else {
-            throw KinError.invalidInput
-        }
-        if (kinString.count > -kinDecimal.exponent) {
-            self.init(sign: .plus,
-            exponent: kinDecimal.exponent,
-            significand: decimal)
-        } else {
-            guard let uint = UInt64(kinString) else {
-                throw KinError.invalidInput
-            }
-            self.init(sign: .plus, exponent: 0,
-            significand: Decimal(uint))
-        }
+    init?(bigInt: GethBigInt) {
+        self.init(string: bigInt.string())
     }
 
-    init(bigInt: GethBigInt) throws {
-        try self.init(kinString: bigInt.string())
+    func kinToWei() -> Decimal {
+        return self / kinDecimal
+    }
+
+    func weiToKin() -> Decimal {
+        return self * kinDecimal
+    }
+
+    func toBigInt() -> GethBigInt? {
+        guard let b = GethNewBigInt(0) else {
+            return nil
+        }
+
+        b.setString(self.description, base: 10)
+
+        return b
     }
 }

--- a/KinSDK/KinSDKTests/KinClientTests.swift
+++ b/KinSDK/KinSDKTests/KinClientTests.swift
@@ -67,44 +67,4 @@ class KinClientTests: XCTestCase {
             XCTAssertTrue(false, "Something went wrong: \(error)")
         }
     }
-    
-    func test_kinToken() {
-
-        let kin100FromDouble = Decimal(100)
-        let bigIntShortString = GethNewBigInt(0)!
-        bigIntShortString.setString("100", base: 10)
-        let bigIntLongString = GethNewBigInt(0)!
-        bigIntLongString.setString("100000000000000000000", base: 10)
-        let bigIntLongStringReminder = GethNewBigInt(0)!
-        bigIntLongStringReminder.setString("100000000000000000001", base: 10)
-
-        guard let kin100FromUnder18CharsString = try? Decimal(kinString: "100") else {
-            XCTAssertTrue(false, "Kin could not be created from short string")
-            return
-        }
-        guard   let kin100FromOver18CharsString = try? Decimal(kinString: "100000000000000000000"),
-                let kin100FromOver18CharsStringWithReminder = try? Decimal(kinString: "100000000000000000001") else {
-            XCTAssertTrue(false, "Kin could not be created from long string")
-            return
-        }
-        guard   let KinFromBigIntWithInt = try? Decimal(bigInt: GethNewBigInt(100)),
-                let KinFromBigIntWithShortString = try? Decimal(bigInt: bigIntShortString),
-                let KinFromBigIntWithLongString = try? Decimal(bigInt: bigIntLongString),
-                let KinFromBigIntWithLongStringRemoinder = try? Decimal(bigInt: bigIntLongStringReminder) else {
-            XCTAssertTrue(false, "Kin could not be created from GethBigInt")
-            return
-        }
-
-        XCTAssertTrue((kin100FromUnder18CharsString as NSDecimalNumber).uint64Value == 100)
-        XCTAssertEqual(kin100FromUnder18CharsString, kin100FromOver18CharsString)
-        XCTAssertEqual(kin100FromDouble, kin100FromOver18CharsString)
-        XCTAssertTrue(String(describing: kin100FromOver18CharsString) == "100")
-        XCTAssertTrue(String(describing: kin100FromOver18CharsStringWithReminder) == "100.000000000000000001")
-        XCTAssertTrue(String(describing: KinFromBigIntWithLongStringRemoinder) == "100.000000000000000001")
-        XCTAssertNotEqual(kin100FromOver18CharsStringWithReminder, kin100FromOver18CharsString)
-        XCTAssertEqual(kin100FromDouble, KinFromBigIntWithLongString)
-        XCTAssertEqual(kin100FromDouble, KinFromBigIntWithShortString)
-        XCTAssertEqual(kin100FromDouble, KinFromBigIntWithInt)
-
-    }
 }


### PR DESCRIPTION
The only places where KIN should be used is at the API boundaries.

- the value for a transaction is specified in KIN.
- the value of the balance or pending balance are expressed in KIN.

Internally, the SDK expresses all values in units of WEI.  The unit transformations are only done at input and output.