### PR TITLE
Fix Contract.init() to fail when address is blank.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ KinSampleApp/KinSampleApp.xcodeproj/xcuserdata
 /truffle.log
 /token-contract-address
 KinSDK/build
+npm-debug.log

--- a/KinSDK/KinSDK/Contract.swift
+++ b/KinSDK/KinSDK/Contract.swift
@@ -33,10 +33,12 @@ class Contract {
         case NetworkIdRopsten:
             address = "0xef2fcc998847db203dea15fc49d0872c7614910c"
         case NetworkIdTruffle:
-            guard let fileUrl = Bundle.main.url(forResource: "testConfig", withExtension: "plist"),
+            guard
+                let fileUrl = Bundle.main.url(forResource: "testConfig", withExtension: "plist"),
                 let data = try? Data(contentsOf: fileUrl),
                 let configDict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
-                let contractAddress = configDict?["TOKEN_CONTRACT_ADDRESS"] as? String else {
+                let contractAddress = configDict?["TOKEN_CONTRACT_ADDRESS"] as? String,
+                contractAddress.isEmpty == false else {
                     fatalError("Seems like you are trying to run tests on the local network, but " +
                         "the tests environment isn't correctly set up. Please see readme for more details")
             }
@@ -44,6 +46,11 @@ class Contract {
         default:
             address = "0xef2fcc998847db203dea15fc49d0872c7614910c"
         }
+
+        guard address.isEmpty == false else {
+            fatalError("No address found!")
+        }
+
         self.contractAddress = GethNewAddressFromHex(address, nil)
         bindContractAbi()
     }

--- a/KinSDK/KinSDKTests/KinTruffleTests.swift
+++ b/KinSDK/KinSDKTests/KinTruffleTests.swift
@@ -45,13 +45,16 @@ class KinTruffleTests: XCTestCase {
                 let account = try kinClient.createAccountIfNeeded(with: key, passphrase: passphrase) {
 
                 print("created account \(account.publicAddress)")
-                XCTAssertNotNil(account)
-                if let balance = try? account.balance() {
-                    XCTAssertEqual((balance as NSDecimalNumber).uint64Value, 1000)
-                } else {
-                    XCTAssertTrue(false, "Couldn't get balance")
-                }
 
+                XCTAssertNotNil(account)
+
+                do {
+                    let balance = try account.balance()
+                    XCTAssertEqual((balance as NSDecimalNumber).uint64Value, 1000)
+                }
+                catch {
+                    XCTAssertTrue(false, "Couldn't get balance: \(error)")
+                }
             } else {
                 XCTAssertTrue(false, "Test rpc did not set up properly. check the build phases for testing")
             }


### PR DESCRIPTION
Tweak test for better failure reporting.