### PR TITLE
Change custom type of NetworkId to require specifying the contract address.

### DIFF
--- a/KinSDK.podspec
+++ b/KinSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KinSDK'
-  s.version          = '0.3.5'
+  s.version          = '0.3.6'
   s.summary          = 'pod for the KIN SDK.'
 
   s.description      = <<-DESC

--- a/KinSDK/KinSDK/source/Contract.swift
+++ b/KinSDK/KinSDK/source/Contract.swift
@@ -46,8 +46,8 @@ final class Contract {
                         "the tests environment isn't correctly set up. Please see readme for more details")
             }
             address = contractAddress
-        default:
-            address = "0xef2fcc998847db203dea15fc49d0872c7614910c"
+        case .custom(_, let contractAddress):
+            address = contractAddress
         }
 
         guard address.isEmpty == false else {

--- a/KinSDK/KinSDK/source/KinClient.swift
+++ b/KinSDK/KinSDK/source/KinClient.swift
@@ -23,8 +23,6 @@ public final class KinClient {
         try self.init(with: provider.url, networkId: provider.networkId)
     }
 
-    private let supportedNetworks: [NetworkId] = [.mainNet, .ropsten, .truffle]
-
     /**
      Instantiates a `KinClient` with a `URL` and a `NetworkId`.
 
@@ -34,10 +32,6 @@ public final class KinClient {
      - throws: `KinError.unsupportedNetwork` if a custom `NetworkId` is used.
      */
     public init(with nodeProviderUrl: URL, networkId: NetworkId) throws {
-        if supportedNetworks.contains(where: { $0 == networkId }) == false {
-            throw KinError.unsupportedNetwork
-        }
-
         self.accountStore = KinAccountStore(url: nodeProviderUrl, networkId: networkId)
     }
 

--- a/KinSDK/KinSDK/source/KinClient.swift
+++ b/KinSDK/KinSDK/source/KinClient.swift
@@ -16,8 +16,6 @@ public final class KinClient {
      Convenience initializer to instantiate a `KinClient` with a `ServiceProvider`.
 
      - parameter provider: The `ServiceProvider` instance that provides the `URL` and `NetworkId`.
-
-     - throws: `KinError.unsupportedNetwork` if a custom `NetworkId` is used.
      */
     public convenience init(provider: ServiceProvider) throws {
         try self.init(with: provider.url, networkId: provider.networkId)
@@ -28,8 +26,6 @@ public final class KinClient {
 
      - parameter nodeProviderUrl: The `URL` of the node this client will communicate to.
      - parameter networkId: The `NetworkId` to be used.
-
-     - throws: `KinError.unsupportedNetwork` if a custom `NetworkId` is used.
      */
     public init(with nodeProviderUrl: URL, networkId: NetworkId) throws {
         self.accountStore = KinAccountStore(url: nodeProviderUrl, networkId: networkId)

--- a/KinSDK/KinSDK/source/KinError.swift
+++ b/KinSDK/KinSDK/source/KinError.swift
@@ -24,12 +24,6 @@ public enum KinError: Error {
     case invalidPassphrase
 
     /**
-     When `KinClient` receives an unsupported `NetworkId` to be initialized with, this error is
-     thrown.
-     */
-    case unsupportedNetwork
-
-    /**
      An invalid address was used as a recipient in a transaction.
      */
     case invalidAddress
@@ -59,8 +53,6 @@ extension KinError: LocalizedError {
             return "Internal Inconsistency"
         case .invalidPassphrase:
             return "Invalid Passphrase"
-        case .unsupportedNetwork:
-            return "Unsupported Network"
         case .invalidAddress:
             return "Invalid Address"
         case .invalidAmount:

--- a/KinSDK/KinSDK/source/NetworkId.swift
+++ b/KinSDK/KinSDK/source/NetworkId.swift
@@ -30,7 +30,7 @@ public enum NetworkId {
     /**
      A network with a custom ID. **Currently unsupported**
      */
-    case custom(value: UInt64)
+    case custom(value: UInt64, contractAddress: String)
 }
 
 extension NetworkId {
@@ -42,7 +42,7 @@ extension NetworkId {
             return 3
         case .truffle:
             return 9
-        case .custom(let value):
+        case .custom(let value, _):
             return value
         }
     }
@@ -59,7 +59,7 @@ extension NetworkId: CustomStringConvertible {
         case .truffle:
             return "truffle"
         default:
-            return "unsupported network"
+            return "custom network"
         }
     }
 }


### PR DESCRIPTION
`Contract` has been updated to take the address from the `enum` value, and `KinClient` has been updated to no longer reject the `custom` value for `NetworkId`.